### PR TITLE
Add RegKey::try_clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ features = [
     "winbase",
     "securitybaseapi",
     "ntdef",
+    "handleapi",
 ]


### PR DESCRIPTION
The naming mirrors types in the standard library that also can't be infallibly cloned.