### PR TITLE
Fix reading integer values

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -333,7 +333,7 @@ pub fn u16_to_u8_vec(mut vec: Vec<u16>) -> Vec<u8> {
         let len = vec.len();
         let ptr = vec.as_mut_ptr();
         std::mem::forget(vec);
-        Vec::from_raw_parts(ptr as *mut u8, len, capacity)
+        Vec::from_raw_parts(ptr as *mut u8, 2 * len, 2 * capacity)
     }
 }
 


### PR DESCRIPTION
In `u16_to_u8_vec()` the resulting vector only has half of the size as expected. The length and capacity should be doubled as  the element size is halved.

I don't think the current implementation works for binary values with an uneven number of bytes. I did not test it but if I read the code correctly, you [add another byte](https://github.com/bbqsrc/registry-rs/blob/18243bd328fe854407712b0da0af8a0b77b9b477/src/value.rs#L308) and [throw away the actual size](https://github.com/bbqsrc/registry-rs/blob/18243bd328fe854407712b0da0af8a0b77b9b477/src/value.rs#L319).