### PR TITLE
Adopt official windows-rs API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,11 @@ log = "0.4.11"
 thiserror = "1.0.20"
 utfx = "0.1"
 
-[dependencies.winapi]
-version = "0.3.9"
+[dependencies.windows]
+version = "0.28.0"
 features = [
-    "winerror",
-    "winreg",
-    "processthreadsapi",
-    "winnt",
-    "winbase",
-    "securitybaseapi",
-    "ntdef",
+    "Win32_System_Registry",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading"
 ]

--- a/examples/private-hive.rs
+++ b/examples/private-hive.rs
@@ -10,8 +10,8 @@ use windows::Win32::{System::Threading::GetCurrentProcess,
     System::Threading::OpenProcessToken
 };
 
-const SE_BACKUP_NAME: str = "SeBackupPrivilege";
-const SE_RESTORE_NAME: str = "SeRestorePrivilege";
+const SE_BACKUP_NAME: &'static str = "SeBackupPrivilege";
+const SE_RESTORE_NAME: &'static str = "SeRestorePrivilege";
 
 fn main() -> Result<(), std::io::Error> {
     let mut token = std::ptr::null_mut();

--- a/examples/private-hive.rs
+++ b/examples/private-hive.rs
@@ -1,13 +1,14 @@
 use registry::{Hive, Security};
 use std::convert::TryInto;
 use utfx::U16CString;
-use windows::Win32::System::Threading::GetCurrentProcess;
-use windows::Win32::Security::{
-    SE_PRIVILEGE_ENABLED, TOKEN_PRIVILEGES, TOKEN_ADJUST_PRIVILEGES, LUID_AND_ATTRIBUTES,
-    AdjustTokenPrivileges, LookupPrivilegeValueW
+use windows::Win32::{System::Threading::GetCurrentProcess,
+    Security::{
+        SE_PRIVILEGE_ENABLED, TOKEN_PRIVILEGES, TOKEN_ADJUST_PRIVILEGES, LUID_AND_ATTRIBUTES,
+        AdjustTokenPrivileges, LookupPrivilegeValueW
+    },
+    Foundation::{LUID, HANDLE},
+    System::Threading::OpenProcessToken
 };
-use windows::Win32::Foundation::{LUID, HANDLE};
-use windows::Win32::System::Threading::OpenProcessToken;
 
 const SE_BACKUP_NAME: str = "SeBackupPrivilege";
 const SE_RESTORE_NAME: str = "SeRestorePrivilege";

--- a/examples/private-hive.rs
+++ b/examples/private-hive.rs
@@ -1,18 +1,17 @@
 use registry::{Hive, Security};
 use std::convert::TryInto;
 use utfx::U16CString;
-use winapi::um::processthreadsapi::GetCurrentProcess;
-use winapi::um::winnt::TOKEN_ADJUST_PRIVILEGES;
-use winapi::{
-    shared::ntdef::LUID,
-    um::{
-        processthreadsapi::OpenProcessToken,
-        securitybaseapi::AdjustTokenPrivileges,
-        winbase::LookupPrivilegeValueW,
-        winnt::LUID_AND_ATTRIBUTES,
-        winnt::{HANDLE, SE_BACKUP_NAME, SE_PRIVILEGE_ENABLED, SE_RESTORE_NAME, TOKEN_PRIVILEGES},
-    },
+use windows::Win32::System::Threading::GetCurrentProcess;
+use windows::Win32::Security::{
+    SE_PRIVILEGE_ENABLED, TOKEN_PRIVILEGES, TOKEN_ADJUST_PRIVILEGES, LUID_AND_ATTRIBUTES,
+    AdjustTokenPrivileges, LookupPrivilegeValueW
 };
+use windows::Win32::Foundation::{LUID, HANDLE};
+use windows::Win32::System::Threading::OpenProcessToken;
+
+const SE_BACKUP_NAME: str = "SeBackupPrivilege";
+const SE_RESTORE_NAME: str = "SeRestorePrivilege";
+
 fn main() -> Result<(), std::io::Error> {
     let mut token = std::ptr::null_mut();
     let r = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &mut token) };

--- a/src/hive.rs
+++ b/src/hive.rs
@@ -1,11 +1,11 @@
 use std::{convert::TryInto, fmt::Display};
 
 use utfx::{U16CStr, U16CString};
-use winapi::um::winreg::{
+use windows::Win32::System::Registry::{
     HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_CURRENT_USER_LOCAL_SETTINGS,
     HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_USERS,
 };
-use winapi::{shared::minwindef::HKEY, um::winreg::RegLoadAppKeyW};
+use windows::Win32::System::Registry::{HKEY, RegLoadAppKeyW};
 
 use crate::key::{self, Error};
 use crate::{sec::Security, RegKey};

--- a/src/hive.rs
+++ b/src/hive.rs
@@ -3,9 +3,8 @@ use std::{convert::TryInto, fmt::Display};
 use utfx::{U16CStr, U16CString};
 use windows::Win32::System::Registry::{
     HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_CURRENT_USER_LOCAL_SETTINGS,
-    HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_USERS,
+    HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_USERS, HKEY, RegLoadAppKeyW
 };
-use windows::Win32::System::Registry::{HKEY, RegLoadAppKeyW};
 
 use crate::key::{self, Error};
 use crate::{sec::Security, RegKey};

--- a/src/hive.rs
+++ b/src/hive.rs
@@ -1,9 +1,12 @@
 use std::{convert::TryInto, fmt::Display};
 
 use utfx::{U16CStr, U16CString};
-use windows::Win32::System::Registry::{
-    HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_CURRENT_USER_LOCAL_SETTINGS,
-    HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_USERS, HKEY, RegLoadAppKeyW
+use windows::Win32::{
+    Foundation::PWSTR,
+    System::Registry::{
+        HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_CURRENT_USER_LOCAL_SETTINGS,
+        HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_USERS, HKEY, RegLoadAppKeyW
+    }
 };
 
 use crate::key::{self, Error};
@@ -130,12 +133,12 @@ where
     P: AsRef<U16CStr>,
 {
     let path = path.as_ref();
-    let mut hkey = std::ptr::null_mut();
-    let result = unsafe { RegLoadAppKeyW(path.as_ptr(), &mut hkey, sec.bits(), 0, 0) };
+    let mut hkey = HKEY::default();
+    let result = unsafe { RegLoadAppKeyW(PWSTR(path.as_ptr() as *mut u16), &mut hkey, sec.bits(), 0, 0) };
 
-    if result == 0 {
+    if result.0 == 0 {
         return Ok(hkey);
     }
 
-    Err(std::io::Error::from_raw_os_error(result))
+    Err(std::io::Error::from_raw_os_error(result.0))
 }

--- a/src/iter/keys.rs
+++ b/src/iter/keys.rs
@@ -4,9 +4,8 @@ use std::{
 };
 
 use utfx::{U16CString, U16String};
-use winapi::shared::winerror::ERROR_NO_MORE_ITEMS;
-use winapi::um::winreg::{RegEnumKeyExW, RegQueryInfoKeyW};
-
+use windows::Win32::Foundation::ERROR_NO_MORE_ITEMS;
+use windows::Win32::System::Registry::{RegEnumKeyExW, RegQueryInfoKeyW};
 use crate::key::RegKey;
 use crate::sec::Security;
 

--- a/src/iter/keys.rs
+++ b/src/iter/keys.rs
@@ -4,8 +4,10 @@ use std::{
 };
 
 use utfx::{U16CString, U16String};
-use windows::Win32::Foundation::ERROR_NO_MORE_ITEMS;
-use windows::Win32::System::Registry::{RegEnumKeyExW, RegQueryInfoKeyW};
+use windows::Win32::{
+    Foundation::ERROR_NO_MORE_ITEMS,
+    System::Registry::{RegEnumKeyExW, RegQueryInfoKeyW}
+};
 use crate::key::RegKey;
 use crate::sec::Security;
 

--- a/src/iter/keys.rs
+++ b/src/iter/keys.rs
@@ -5,7 +5,7 @@ use std::{
 
 use utfx::{U16CString, U16String};
 use windows::Win32::{
-    Foundation::ERROR_NO_MORE_ITEMS,
+    Foundation::{PWSTR, ERROR_NO_MORE_ITEMS},
     System::Registry::{RegEnumKeyExW, RegQueryInfoKeyW}
 };
 use crate::key::RegKey;
@@ -85,22 +85,22 @@ impl<'a> Iterator for Keys<'a> {
             RegEnumKeyExW(
                 self.regkey.handle,
                 self.index,
-                self.buf.as_mut_ptr(),
+                PWSTR(self.buf.as_mut_ptr()),
                 &mut len,
                 null_mut(),
-                null_mut(),
+                PWSTR::default(),
                 null_mut(),
                 null_mut(),
             )
         };
 
-        if result == ERROR_NO_MORE_ITEMS as i32 {
+        if result.0 == ERROR_NO_MORE_ITEMS.0 as i32 {
             return None;
         }
 
         self.index += 1;
 
-        if result != 0 {
+        if result.0 != 0 {
             // TODO: don't panic
             panic!();
         }
@@ -125,7 +125,7 @@ impl<'a> Keys<'a> {
         let result = unsafe {
             RegQueryInfoKeyW(
                 regkey.handle,
-                null_mut(),
+                PWSTR::default(),
                 null_mut(),
                 null_mut(),
                 null_mut(), // &mut subkeys_len,
@@ -139,7 +139,7 @@ impl<'a> Keys<'a> {
             )
         };
 
-        if result == 0 {
+        if result.0 == 0 {
             return Ok(Keys {
                 regkey,
                 buf: vec![0u16; subkeys_max_str_len as usize + 1],
@@ -147,6 +147,6 @@ impl<'a> Keys<'a> {
             });
         }
 
-        Err(std::io::Error::from_raw_os_error(result))
+        Err(std::io::Error::from_raw_os_error(result.0))
     }
 }

--- a/src/iter/values.rs
+++ b/src/iter/values.rs
@@ -1,8 +1,10 @@
 use std::{convert::TryInto, fmt::Debug, ptr::null_mut};
 
 use utfx::{U16CStr, U16CString};
-use windows::Win32::Foundation::ERROR_NO_MORE_ITEMS;
-use windows::Win32::System::Registry::{RegEnumKeyExW, RegQueryInfoKeyW};
+use windows::Win32::{
+    Foundation::ERROR_NO_MORE_ITEMS,
+    System::Registry::RegQueryInfoKeyW
+};
 
 use crate::{key::RegKey, Data};
 

--- a/src/iter/values.rs
+++ b/src/iter/values.rs
@@ -1,8 +1,8 @@
 use std::{convert::TryInto, fmt::Debug, ptr::null_mut};
 
 use utfx::{U16CStr, U16CString};
-use winapi::shared::winerror::ERROR_NO_MORE_ITEMS;
-use winapi::um::winreg::{RegEnumValueW, RegQueryInfoKeyW};
+use windows::Win32::Foundation::ERROR_NO_MORE_ITEMS;
+use windows::Win32::System::Registry::{RegEnumKeyExW, RegQueryInfoKeyW};
 
 use crate::{key::RegKey, Data};
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,9 +6,8 @@ use std::{
 };
 
 use utfx::{U16CStr, U16CString};
-use winapi::shared::minwindef::HKEY;
-use winapi::um::winreg::{
-    RegCloseKey, RegCreateKeyExW, RegDeleteKeyW, RegDeleteTreeW, RegOpenCurrentUser, RegOpenKeyExW,
+use windows::Win32::System::Registry::{
+    HKEY, RegCloseKey, RegCreateKeyExW, RegDeleteKeyW, RegDeleteTreeW, RegOpenCurrentUser, RegOpenKeyExW,
     RegSaveKeyExW,
 };
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,8 +6,7 @@ use std::{
 };
 
 use utfx::U16CString;
-use winapi::shared::minwindef::HKEY;
-use winapi::um::winreg::{RegDeleteValueW, RegQueryValueExW, RegSetValueExW};
+use windows::Win32::System::Registry::{HKEY, RegDeleteValueW, RegQueryValueExW, RegSetValueExW};
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/src/value.rs
+++ b/src/value.rs
@@ -308,7 +308,7 @@ where
 
     // sz is size in bytes, we'll make a u16 vec.
     let mut buf: Vec<u16> = vec![0u16; (sz / 2 + sz % 2) as usize];
-    let mut ty = 0u32;
+    let mut ty = REG_VALUE_TYPE(0);
 
     // Get the actual value
     let result = unsafe {
@@ -316,7 +316,7 @@ where
             base,
             PWSTR(value_name.as_ptr() as *mut u16),
             null_mut(),
-            &mut REG_VALUE_TYPE(ty),
+            &mut ty,
             buf.as_mut_ptr() as *mut u8,
             &mut sz,
         )
@@ -326,7 +326,7 @@ where
         return Err(Error::from_code(result.0, value_name.to_string_lossy()));
     }
 
-    parse_value_type_data(ty, buf)
+    parse_value_type_data(ty.0, buf)
 }
 
 pub fn u16_to_u8_vec(mut vec: Vec<u16>) -> Vec<u8> {


### PR DESCRIPTION
I do not know if this works. I am fairly new to Rust, but I did my best. I did this because I do not want both `winapi` and `windows-rs` as dependencies in my future project. Please see https://github.com/rust-windowing/winit/pull/2057, as my contribution is based off of this.

Please leave comments on any problems with the changes, and I will be sure to fix them. I do not know how you are testing this, I may wish to implement tests for you. 😄 