### PR TITLE
Fix panic due to missing null in MultiString

### DIFF
--- a/src/hive.rs
+++ b/src/hive.rs
@@ -97,7 +97,10 @@ impl Hive {
         if !file_path.as_ref().exists() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("No hive found at path: {:?}", file_path.as_ref()),
+                format!(
+                    "No hive found at path: {:?}",
+                    file_path.as_ref()
+                ),
             ));
         }
         let path = U16CString::from_os_str(file_path.as_ref().as_os_str())
@@ -132,11 +135,21 @@ where
 {
     let path = path.as_ref();
     let mut hkey = std::ptr::null_mut();
-    let result = unsafe { RegLoadAppKeyW(path.as_ptr(), &mut hkey, sec.bits(), 0, 0) };
+    let result = unsafe {
+        RegLoadAppKeyW(
+            path.as_ptr(),
+            &mut hkey,
+            sec.bits(),
+            0,
+            0,
+        )
+    };
 
     if result == 0 {
         return Ok(hkey);
     }
 
-    Err(std::io::Error::from_raw_os_error(result))
+    Err(std::io::Error::from_raw_os_error(
+        result,
+    ))
 }

--- a/src/iter/keys.rs
+++ b/src/iter/keys.rs
@@ -146,6 +146,8 @@ impl<'a> Keys<'a> {
             });
         }
 
-        Err(std::io::Error::from_raw_os_error(result))
+        Err(std::io::Error::from_raw_os_error(
+            result,
+        ))
     }
 }

--- a/src/iter/values.rs
+++ b/src/iter/values.rs
@@ -180,6 +180,8 @@ impl<'a> Values<'a> {
             });
         }
 
-        Err(std::io::Error::from_raw_os_error(result))
+        Err(std::io::Error::from_raw_os_error(
+            result,
+        ))
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -152,7 +152,11 @@ impl RegKey {
 
     #[inline]
     pub fn delete_self(self, is_recursive: bool) -> Result<(), Error> {
-        delete_hkey(self.handle, U16CString::default(), is_recursive)
+        delete_hkey(
+            self.handle,
+            U16CString::default(),
+            is_recursive,
+        )
     }
 
     #[inline]
@@ -186,7 +190,7 @@ impl RegKey {
     pub fn keys(&self) -> iter::Keys<'_> {
         match iter::Keys::new(self) {
             Ok(v) => v,
-            Err(e) => unreachable!(e),
+            Err(e) => unreachable!("{}", e),
         }
     }
 
@@ -194,7 +198,7 @@ impl RegKey {
     pub fn values(&self) -> iter::Values<'_> {
         match iter::Values::new(self) {
             Ok(v) => v,
-            Err(e) => unreachable!(e),
+            Err(e) => unreachable!("{}", e),
         }
     }
 
@@ -224,7 +228,15 @@ where
 {
     let path = path.as_ref();
     let mut hkey = std::ptr::null_mut();
-    let result = unsafe { RegOpenKeyExW(base, path.as_ptr(), 0, sec.bits(), &mut hkey) };
+    let result = unsafe {
+        RegOpenKeyExW(
+            base,
+            path.as_ptr(),
+            0,
+            sec.bits(),
+            &mut hkey,
+        )
+    };
 
     if result == 0 {
         return Ok(hkey);
@@ -240,7 +252,14 @@ where
     P: AsRef<U16CStr>,
 {
     let path = path.as_ref();
-    let result = unsafe { RegSaveKeyExW(hkey, path.as_ptr(), std::ptr::null_mut(), 4) };
+    let result = unsafe {
+        RegSaveKeyExW(
+            hkey,
+            path.as_ptr(),
+            std::ptr::null_mut(),
+            4,
+        )
+    };
 
     if result == 0 {
         return Ok(());
@@ -307,9 +326,15 @@ mod tests {
     #[test]
     fn test_paths() {
         let key = Hive::CurrentUser
-            .open("SOFTWARE\\Microsoft", crate::Security::Read)
+            .open(
+                "SOFTWARE\\Microsoft",
+                crate::Security::Read,
+            )
             .unwrap();
-        assert_eq!(key.to_string(), "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft")
+        assert_eq!(
+            key.to_string(),
+            "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft"
+        )
     }
 
     #[test]
@@ -327,7 +352,10 @@ mod tests {
     #[test]
     fn non_existent_value() {
         let key = Hive::CurrentUser
-            .open("SOFTWARE\\Microsoft", crate::Security::Read)
+            .open(
+                "SOFTWARE\\Microsoft",
+                crate::Security::Read,
+            )
             .unwrap();
         let value_err = key
             .value("4e996ef6-a4ef-4026-b9fc-464d352d35ee")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,10 @@ mod tests {
     #[test]
     fn open_key() {
         let result = Hive::CurrentUser
-            .open(r"SOFTWARE\Microsoft", Security::AllAccess)
+            .open(
+                r"SOFTWARE\Microsoft",
+                Security::AllAccess,
+            )
             .unwrap();
         println!("{}", result);
     }
@@ -74,7 +77,10 @@ mod tests {
     #[test]
     fn iter_keys() {
         let regkey = Hive::CurrentUser
-            .open(r"SOFTWARE\Microsoft", Security::AllAccess)
+            .open(
+                r"SOFTWARE\Microsoft",
+                Security::AllAccess,
+            )
             .unwrap();
         let results = regkey.keys().collect::<Result<Vec<_>, _>>().unwrap();
         println!("{:?}", &results);
@@ -83,7 +89,10 @@ mod tests {
     #[test]
     fn iter_values() {
         let regkey = Hive::CurrentUser
-            .open(r"Keyboard Layout\Preload", Security::Read)
+            .open(
+                r"Keyboard Layout\Preload",
+                Security::Read,
+            )
             .unwrap();
         let results = regkey.values().collect::<Result<Vec<_>, _>>().unwrap();
         println!("{:?}", &results);
@@ -105,10 +114,16 @@ mod tests {
     #[test]
     fn set_value_and_delete() {
         let regkey = Hive::CurrentUser
-            .create(r"Test\registry-rust-crate", Security::AllAccess)
+            .create(
+                r"Test\registry-rust-crate",
+                Security::AllAccess,
+            )
             .unwrap();
         regkey
-            .set_value("test", &Data::String("Meow meow".try_into().unwrap()))
+            .set_value(
+                "test",
+                &Data::String("Meow meow".try_into().unwrap()),
+            )
             .unwrap();
         regkey
             .set_value(
@@ -121,7 +136,10 @@ mod tests {
             .unwrap();
         regkey.set_value("nothing", &Data::None).unwrap();
         regkey
-            .set_value("some binary", &Data::Binary(vec![1, 2, 3, 4, 255]))
+            .set_value(
+                "some binary",
+                &Data::Binary(vec![1, 2, 3, 4, 255]),
+            )
             .unwrap();
         regkey.set_value("u32", &Data::U32(0x1234FEFE)).unwrap();
         regkey.set_value("u32be", &Data::U32BE(0x1234FEFE)).unwrap();

--- a/src/value.rs
+++ b/src/value.rs
@@ -117,7 +117,11 @@ impl Debug for Data {
                 write!(f, "String({:?})", s.to_string_lossy())
             }
             Data::ExpandString(s) => {
-                write!(f, "ExpandString({:?})", s.to_string_lossy())
+                write!(
+                    f,
+                    "ExpandString({:?})",
+                    s.to_string_lossy()
+                )
             }
             Data::Binary(s) => write!(f, "Binary({:?})", s),
             Data::U32(x) => write!(f, "U32({})", x),
@@ -225,7 +229,7 @@ fn parse_wide_string_nul(vec: Vec<u16>) -> Result<U16CString, Error> {
 
 fn parse_wide_multi_string(vec: Vec<u16>) -> Result<Vec<U16CString>, Error> {
     let len = vec.len();
-    if vec[len - 1] != 0 || vec[len - 2] != 0 {
+    if len < 2 || vec[len - 1] != 0 || vec[len - 2] != 0 {
         return Err(Error::MissingMultiNul);
     }
 
@@ -257,7 +261,10 @@ where
     };
 
     if result != 0 {
-        return Err(Error::from_code(result, value_name.to_string_lossy()));
+        return Err(Error::from_code(
+            result,
+            value_name.to_string_lossy(),
+        ));
     }
 
     Ok(())
@@ -273,7 +280,10 @@ where
     let result = unsafe { RegDeleteValueW(base, value_name.as_ptr()) };
 
     if result != 0 {
-        return Err(Error::from_code(result, value_name.to_string_lossy()));
+        return Err(Error::from_code(
+            result,
+            value_name.to_string_lossy(),
+        ));
     }
 
     Ok(())
@@ -301,7 +311,10 @@ where
     };
 
     if result != 0 {
-        return Err(Error::from_code(result, value_name.to_string_lossy()));
+        return Err(Error::from_code(
+            result,
+            value_name.to_string_lossy(),
+        ));
     }
 
     // sz is size in bytes, we'll make a u16 vec.
@@ -321,7 +334,10 @@ where
     };
 
     if result != 0 {
-        return Err(Error::from_code(result, value_name.to_string_lossy()));
+        return Err(Error::from_code(
+            result,
+            value_name.to_string_lossy(),
+        ));
     }
 
     parse_value_type_data(ty, buf)


### PR DESCRIPTION
When attempting to read a MultiString that is completely empty (even without the double null at the end), the library panics as it attempts to index an empty vec. This adds a length check before it indexes the vec, preventing the panic.